### PR TITLE
Remove VTK dep

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
 
 test:
   imports:
-    - geovista 
+    - geovista
   commands:
     - pip check
     - geovista --help
@@ -58,7 +58,8 @@ about:
     It leverages the power of the GPU through VTK to provide a paradigm
     shift in rendering performance and interactive user experience.
   dev_url: https://github.com/bjlittle/geovista
-  
+
 extra:
   recipe-maintainers:
     - bjlittle
+    - banesullivan

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: dd6af86aa908b36fb9114a9558f439999fdd929a35df371266a31a452905b4d9
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
@@ -36,7 +36,6 @@ requirements:
     - pykdtree
     - pyproj >=3.3
     - pyvista >=0.40
-    - vtk >=9.2.6
 
 test:
   imports:


### PR DESCRIPTION
Let the PyVista dependency handle the VTK dependency which does not constrain the version. Why? Because many users need to specify specific builds of VTK which are constrained by the version string. For example: `vtk=*=osmesa*` -- This recipe is incompatible with these versions/variants of VTK.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
